### PR TITLE
Feature: Blender update button in OP menu

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -426,6 +426,7 @@ class WM_OT_CheckWorkfileUpToDate(bpy.types.Operator):
                 return {"CANCELLED"}
         elif self.action == "QUIT":
             bpy.ops.wm.quit_blender()
+            return {"FINISHED"}
         elif self.action == "PROCEED":
             return {"FINISHED"}
         else:
@@ -452,7 +453,7 @@ class TOPBAR_MT_avalon(bpy.types.Menu):
         # Display workfile out of date warning
         if not context.scene.is_workfile_up_to_date:
             row = layout.row()
-            row.label(text="Your workfile is out of date!", icon="ERROR")
+            row.operator(WM_OT_CheckWorkfileUpToDate.bl_idname, text="Your workfile is out of date!", icon="ERROR")
             layout.separator()
 
         pcoll = PREVIEW_COLLECTIONS.get("avalon")


### PR DESCRIPTION
# Description
Replaced the workfile out of date label in the OpenPype menu by a button calling the check for update operator.
Also fixed a missing return value in said operator, causing an error when user selects "Quit blender".

# Steps to test
- Open an out of date workfile
- Select proceed anyway
- Open the OpenPype menu
- Click on the workfile out of date button
- The workfile out of date popup should appear (And the quit blender option should not cause an error).