### PR TITLE
Fix: Workfile out of date when publishing workfile only

### DIFF
--- a/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
+++ b/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
@@ -9,7 +9,7 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     label = "Increment Workfile Version"
     optional = True
     hosts = ["blender"]
-    families = ["workfile"]
+    families = ["workfile", "animation", "model", "rig", "action", "layout"]
 
     def process(self, context):
 

--- a/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
+++ b/openpype/hosts/blender/plugins/publish/increment_workfile_version.py
@@ -9,7 +9,7 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     label = "Increment Workfile Version"
     optional = True
     hosts = ["blender"]
-    families = ["animation", "model", "rig", "action", "layout"]
+    families = ["workfile"]
 
     def process(self, context):
 


### PR DESCRIPTION
## Description
Fixing workfiles being marked as out of date after publishing a workfile only then quitting without saving (Users are not prompted to save if they didn't change anything after publish).

## Testing notes:
- Publish a workfile with no other subsets.
- Quit blender without saving.
- Reopen the workfile.
- The workfile should be marked as up to date.