### PR TITLE
Fix: No remap after download last workfile

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -420,6 +420,7 @@ class WM_OT_CheckWorkfileUpToDate(bpy.types.Operator):
                 context.scene.is_workfile_up_to_date = True
 
                 bpy.ops.wm.save_mainfile()
+                bpy.ops.wm.revert_mainfile()
                 return {"FINISHED"}
             else:
                 self.report({"ERROR"}, "Failed to download last workfile.")


### PR DESCRIPTION
## Description
Fixing no remap after using `download last workfile` in blender host. To be more precise, remaps could happen before if you revert after using the operator, so reverting is now part of it.

## Testing notes:
- Open an out of date workfile in blender.
- Select download last workfile on the pop up panel.
- Paths should be correct, unless there was an issue during publish of the last workfile.