### PR TITLE
Bugfix/dl last wf no increment

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Union
 import bpy
 import addon_utils
 from openpype.lib import Logger
-from openpype.lib.path_tools import get_version_from_path
 from openpype.modules import ModulesManager
 from openpype.pipeline import (
     Anatomy,

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -19,7 +19,6 @@ from openpype.pipeline import (
 )
 from openpype.pipeline.template_data import (
     get_template_data,
-    get_template_data_with_names,
 )
 from openpype.pipeline.workfile.path_resolving import (
     get_workfile_template_key,

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -424,6 +424,7 @@ def download_last_workfile() -> str:
         'blender',
     )
 
+    # Get workfile version
     workfile_data['version'] = get_last_workfile_with_version(
         Path(bpy.data.filepath).parent.as_posix(),
         anatomy.templates[get_workfile_template_key(
@@ -439,6 +440,7 @@ def download_last_workfile() -> str:
         get_workfile_template_key(task_name, 'blender', project_name)
     ]['path']
 
+    # Download and get last workfile
     last_published_workfile_path = download_last_published_workfile(
         "blender",
         project_name,

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -3,6 +3,7 @@ import shutil
 import traceback
 import importlib
 import contextlib
+from pathlib import Path
 from typing import Dict, List, Union
 
 import bpy
@@ -16,9 +17,13 @@ from openpype.pipeline import (
     get_current_asset_name,
     get_current_task_name,
 )
-from openpype.pipeline.template_data import get_template_data
+from openpype.pipeline.template_data import (
+    get_template_data,
+    get_template_data_with_names,
+)
 from openpype.pipeline.workfile.path_resolving import (
     get_workfile_template_key,
+    get_last_workfile_with_version,
 )
 from openpype.client.entities import (
     get_subsets,
@@ -421,11 +426,14 @@ def download_last_workfile() -> str:
         'blender',
     )
 
-    # TODO Get highest local version number
-    # TODO Handle subversion
-    workfile_data['version'] = int(
-        get_version_from_path(bpy.data.filepath)
-    ) + 1
+    workfile_data['version'] = get_last_workfile_with_version(
+        Path(bpy.data.filepath).parent.as_posix(),
+        anatomy.templates[get_workfile_template_key(
+            task_name, 'blender', project_name
+        )]['file'],
+        workfile_data,
+        ['blend'],
+    )[1] + 1
     workfile_data['ext'] = 'blend'
 
     # Get local workfile path
@@ -433,20 +441,25 @@ def download_last_workfile() -> str:
         get_workfile_template_key(task_name, 'blender', project_name)
     ]['path']
 
+    last_published_workfile_path = download_last_published_workfile(
+        "blender",
+        project_name,
+        task_name,
+        workfile_representation,
+        int((
+            sync_server.sync_project_settings[
+                project_name
+            ]['config']['retry_cnt']
+        )),
+        anatomy=anatomy,
+    )
+
+    if not last_published_workfile_path or not Path(last_published_workfile_path).exists():
+        raise OSError('Failed to download last published workfile')
+
     # Download and copy last published workfile to local workfile path
     shutil.copy(
-        download_last_published_workfile(
-            "blender",
-            project_name,
-            task_name,
-            workfile_representation,
-            int((
-                sync_server.sync_project_settings[
-                    project_name
-                ]['config']['retry_cnt']
-            )),
-            anatomy=anatomy,
-        ),
+        last_published_workfile_path,
         local_workfile_path,
     )
 

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import traceback
 import importlib
 import contextlib
@@ -14,11 +15,16 @@ from openpype.pipeline import (
     get_current_asset_name,
     get_current_task_name,
 )
+from openpype.pipeline.template_data import get_template_data
+from openpype.pipeline.workfile.path_resolving import (
+    get_workfile_template_key,
+)
 from openpype.client.entities import (
     get_subsets,
     get_representations,
     get_last_version_by_subset_id,
     get_asset_by_name,
+    get_project,
 )
 
 from . import pipeline
@@ -406,16 +412,40 @@ def download_last_workfile() -> str:
             f"'{task_name}' and host blender"
         )
 
-    # Download last published workfile and return its path
-    return download_last_published_workfile(
-        "blender",
-        project_name,
+    # Get workfile template data
+    workfile_data = get_template_data(
+        get_project(project_name, inactive=False),
+        asset_doc,
         task_name,
-        workfile_representation,
-        int((
-            sync_server.sync_project_settings[
-                project_name
-            ]['config']['retry_cnt']
-        )),
-        anatomy=anatomy,
-    ), last_version_doc["data"]["time"]
+        'blender',
+    )
+
+    # Increment workfile version number
+    workfile_data['version'] = (
+        workfile_representation['context']['version'] + 1
+    )
+
+    # Get local workfile path
+    local_workfile_path = anatomy.format(workfile_data)[
+        get_workfile_template_key(task_name, 'blender', project_name)
+    ]['path']
+
+    # Download and copy last published workfile to local workfile path
+    shutil.copy(
+        download_last_published_workfile(
+            "blender",
+            project_name,
+            task_name,
+            workfile_representation,
+            int((
+                sync_server.sync_project_settings[
+                    project_name
+                ]['config']['retry_cnt']
+            )),
+            anatomy=anatomy,
+        ),
+        local_workfile_path,
+    )
+
+    return local_workfile_path, last_version_doc['data']['time']
+

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -329,11 +329,9 @@ def download_last_workfile() -> str:
         download_last_published_workfile,
     )
 
-    sync_server = ModulesManager().get('sync_server')
+    sync_server = ModulesManager().get("sync_server")
     if not sync_server or not sync_server.enabled:
-        raise RuntimeError(
-            'Sync server module is not enabled or available'
-        )
+        raise RuntimeError("Sync server module is not enabled or available")
 
     project_name = get_current_project_name()
     task_name = get_current_task_name()
@@ -343,25 +341,25 @@ def download_last_workfile() -> str:
         project_name,
         asset_name,
     )
-    family = 'workfile'
+    family = "workfile"
 
     filtered_subsets = [
         subset
         for subset in get_subsets(
             project_name,
-            asset_ids=[asset_doc['_id']],
-            fields=['_id', 'name', 'data.family', 'data.families'],
+            asset_ids=[asset_doc["_id"]],
+            fields=["_id", "name", "data.family", "data.families"],
         )
         if (
-            subset['data'].get('family') == family
+            subset["data"].get("family") == family
             # Legacy compatibility
-            or family in subset['data'].get('families', {})
+            or family in subset["data"].get("families", {})
         )
     ]
     if not filtered_subsets:
         raise RuntimeError(
             "Not any subset for asset '{}' with id '{}'".format(
-                asset_doc['name'], asset_doc['_id']
+                asset_doc["name"], asset_doc["_id"]
             )
         )
 
@@ -369,10 +367,10 @@ def download_last_workfile() -> str:
     low_task_name = task_name.lower()
     if len(filtered_subsets) > 1:
         for subset in filtered_subsets:
-            if low_task_name in subset['name'].lower():
-                subset_id = subset['_id']  # What if none is found?
+            if low_task_name in subset["name"].lower():
+                subset_id = subset["_id"]  # What if none is found?
     else:
-        subset_id = filtered_subsets[0]['_id']
+        subset_id = filtered_subsets[0]["_id"]
 
     if subset_id is None:
         print(
@@ -389,14 +387,16 @@ def download_last_workfile() -> str:
         print("Subset does not have any version")
         return
 
-    workfile_representations = list(get_representations(
-        project_name,
-        context_filters={
-            'asset': asset_name,
-            'family': 'workfile',
-            'task': {'name': task_name},
-        }
-    ))
+    workfile_representations = list(
+        get_representations(
+            project_name,
+            context_filters={
+                "asset": asset_name,
+                "family": "workfile",
+                "task": {"name": task_name},
+            },
+        )
+    )
 
     if not workfile_representations:
         raise RuntimeError(
@@ -405,15 +405,14 @@ def download_last_workfile() -> str:
 
     workfile_representation = max(
         filter(
-            lambda r: r['context'].get('version'),
+            lambda r: r["context"].get("version"),
             workfile_representations,
         ),
-        key=lambda r: r['context']['version'],
+        key=lambda r: r["context"]["version"],
     )
     if not workfile_representation:
         raise RuntimeError(
-            "No published workfile for task "
-            f"'{task_name}' and host blender"
+            "No published workfile for task " f"'{task_name}' and host blender"
         )
 
     # Get workfile template data
@@ -421,24 +420,27 @@ def download_last_workfile() -> str:
         get_project(project_name, inactive=False),
         asset_doc,
         task_name,
-        'blender',
+        "blender",
     )
 
     # Get workfile version
-    workfile_data['version'] = get_last_workfile_with_version(
-        Path(bpy.data.filepath).parent.as_posix(),
-        anatomy.templates[get_workfile_template_key(
-            task_name, 'blender', project_name
-        )]['file'],
-        workfile_data,
-        ['blend'],
-    )[1] + 1
-    workfile_data['ext'] = 'blend'
+    workfile_data["version"] = (
+        get_last_workfile_with_version(
+            Path(bpy.data.filepath).parent.as_posix(),
+            anatomy.templates[
+                get_workfile_template_key(task_name, "blender", project_name)
+            ]["file"],
+            workfile_data,
+            ["blend"],
+        )[1]
+        + 1
+    )
+    workfile_data["ext"] = "blend"
 
     # Get local workfile path
     local_workfile_path = anatomy.format(workfile_data)[
-        get_workfile_template_key(task_name, 'blender', project_name)
-    ]['path']
+        get_workfile_template_key(task_name, "blender", project_name)
+    ]["path"]
 
     # Download and get last workfile
     last_published_workfile_path = download_last_published_workfile(
@@ -446,16 +448,21 @@ def download_last_workfile() -> str:
         project_name,
         task_name,
         workfile_representation,
-        int((
-            sync_server.sync_project_settings[
-                project_name
-            ]['config']['retry_cnt']
-        )),
+        int(
+            (
+                sync_server.sync_project_settings[project_name]["config"][
+                    "retry_cnt"
+                ]
+            )
+        ),
         anatomy=anatomy,
     )
 
-    if not last_published_workfile_path or not Path(last_published_workfile_path).exists():
-        raise OSError('Failed to download last published workfile')
+    if (
+        not last_published_workfile_path
+        or not Path(last_published_workfile_path).exists()
+    ):
+        raise OSError("Failed to download last published workfile")
 
     # Download and copy last published workfile to local workfile path
     shutil.copy(
@@ -463,4 +470,4 @@ def download_last_workfile() -> str:
         local_workfile_path,
     )
 
-    return local_workfile_path, last_version_doc['data']['time']
+    return local_workfile_path, last_version_doc["data"]["time"]

--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Union
 import bpy
 import addon_utils
 from openpype.lib import Logger
+from openpype.lib.path_tools import get_version_from_path
 from openpype.modules import ModulesManager
 from openpype.pipeline import (
     Anatomy,
@@ -420,10 +421,12 @@ def download_last_workfile() -> str:
         'blender',
     )
 
-    # Increment workfile version number
-    workfile_data['version'] = (
-        workfile_representation['context']['version'] + 1
-    )
+    # TODO Get highest local version number
+    # TODO Handle subversion
+    workfile_data['version'] = int(
+        get_version_from_path(bpy.data.filepath)
+    ) + 1
+    workfile_data['ext'] = 'blend'
 
     # Get local workfile path
     local_workfile_path = anatomy.format(workfile_data)[
@@ -448,4 +451,3 @@ def download_last_workfile() -> str:
     )
 
     return local_workfile_path, last_version_doc['data']['time']
-


### PR DESCRIPTION
## Description
Fixing workfile downloaded using the `Download last workfile` operator overwriting current workfile by ensuring the newly downloaded workfile version number is last local workfile version + 1.

## Testing notes
- Open an out of date workfile.
- Select download last workfile on the popup window.
- The newly downloaded workfile should have last local workfile version + 1 as its version number.

I recommend doing the same test with a workfile which is not your last local workfile (By using `copy and open` in the workfile menu).