### PR TITLE
Fix: Blend file stuck while opening

### DIFF
--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -541,6 +541,13 @@ def register():
         update_workfile_up_to_date, first_interval=0, persistent=True
     )
 
+    # Use a timer to delay execution of check_workfile_up_to_date
+    def run_op_check_workfile_up_to_date():
+        if hasattr(
+            bpy.types, bpy.ops.wm.check_workfile_up_to_date.idname()
+        ):
+            bpy.ops.wm.check_workfile_up_to_date("INVOKE_DEFAULT")
+    bpy.app.timers.register(run_op_check_workfile_up_to_date, persistent=True)
 
 def unregister():
     """Unregister the operators and menu."""

--- a/openpype/hosts/blender/api/ops.py
+++ b/openpype/hosts/blender/api/ops.py
@@ -542,12 +542,12 @@ def register():
     )
 
     # Use a timer to delay execution of check_workfile_up_to_date
-    def run_op_check_workfile_up_to_date():
+    def delayed_check_workfile_up_to_date():
         if hasattr(
             bpy.types, bpy.ops.wm.check_workfile_up_to_date.idname()
         ):
             bpy.ops.wm.check_workfile_up_to_date("INVOKE_DEFAULT")
-    bpy.app.timers.register(run_op_check_workfile_up_to_date, persistent=True)
+    bpy.app.timers.register(delayed_check_workfile_up_to_date, persistent=True)
 
 def unregister():
     """Unregister the operators and menu."""

--- a/openpype/hosts/blender/api/pipeline.py
+++ b/openpype/hosts/blender/api/pipeline.py
@@ -131,11 +131,6 @@ def on_new():
 
 def on_open():
     set_start_end_frames()
-    if hasattr(
-        bpy.types, bpy.ops.wm.check_workfile_up_to_date.idname()
-    ):
-        bpy.ops.wm.check_workfile_up_to_date("INVOKE_DEFAULT")
-
 
 
 @bpy.app.handlers.persistent


### PR DESCRIPTION
## Brief description
Current implementation might freeze Blender while opening if the scene is big. The fix uses a timer to guarantee the operator is run once the scene is initialized.