### PR TITLE
Bugfix: Copy Resources backslash in main path

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -195,8 +195,8 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Copy resources to the local resources directory
         for file in workfile_representation['files']:
-            resource_main_path = file['path'].replace(
-                '{root[main]}', str(anatomy.roots['main'])
+            resource_main_path = file["path"].replace(
+                "{root[main]}", str(anatomy.roots["main"])
             )
 
             # Only copy if the resource file exists, and it's not the workfile

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import filecmp
 
@@ -196,9 +195,10 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Copy resources to the local resources directory
         for file in workfile_representation['files']:
-            resource_main_path = re.sub(
-                r"\{root\[main\]\}", str(anatomy.roots['main']), file['path']
+            resource_main_path = file['path'].replace(
+                '{root[main]}', str(anatomy.roots['main'])
             )
+
             # Only copy if the resource file exists, and it's not the workfile
             if (
                 os.path.exists(resource_main_path)


### PR DESCRIPTION
## Changelog Description
Fixing errors when main path contains `\` character.

## Testing notes
- Download a workfile which must be locally unavailable (Fab_old technique).
- Resources should be copied to the `resources` folder without error.
- This should work on windows with `\` in path.