### PR TITLE
Enhancement: Using anatomy to get resource main path

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -195,9 +195,8 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
 
         # Copy resources to the local resources directory
         for file in workfile_representation['files']:
-            resource_main_path = file["path"].replace(
-                "{root[main]}", str(anatomy.roots["main"])
-            )
+            # Get resource main path
+            resource_main_path = anatomy.fill_root(file['path'])
 
             # Only copy if the resource file exists, and it's not the workfile
             if (

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -197,13 +197,15 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         for file in workfile_representation['files']:
             # Get resource main path
             resource_main_path = anatomy.fill_root(file["path"])
+            resource_basename = os.path.basename(resource_main_path)
 
             # Only copy if the resource file exists, and it's not the workfile
             if (
                 os.path.exists(resource_main_path)
-                and resource_main_path != last_published_workfile_path
+                and resource_basename != os.path.basename(
+                    last_published_workfile_path
+                )
             ):
-                resource_basename = os.path.basename(resource_main_path)
                 resource_work_path = os.path.join(
                     resources_dir, resource_basename
                 )

--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -196,7 +196,7 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         # Copy resources to the local resources directory
         for file in workfile_representation['files']:
             # Get resource main path
-            resource_main_path = anatomy.fill_root(file['path'])
+            resource_main_path = anatomy.fill_root(file["path"])
 
             # Only copy if the resource file exists, and it's not the workfile
             if (


### PR DESCRIPTION
## Changelog Description
As pointed out by two other @kaamaurice as well as another developer from Ynput, we should not directly access `root{main}` to fill the root path, as this site can be blank or named differently. This branch brings changes to fill root path from anatomy instead, which is the preferred way of handling this.

## Testing notes
- Download a locally unavailable workfile (fab_old technique).
- Resources should be copied the `resources` folder.
- It should not cause errors on Windows if the root path uses `\`.