### PR TITLE
Bugfix: Workfile copied in resources

### DIFF
--- a/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
+++ b/openpype/modules/sync_server/launch_hooks/pre_copy_last_published_workfile.py
@@ -197,13 +197,15 @@ class CopyLastPublishedWorkfile(PreLaunchHook):
         for file in workfile_representation['files']:
             # Get resource main path
             resource_main_path = anatomy.fill_root(file["path"])
+            resource_basename = os.path.basename(resource_main_path)
 
             # Only copy if the resource file exists, and it's not the workfile
             if (
                 os.path.exists(resource_main_path)
-                and resource_main_path != last_published_workfile_path
+                and resource_basename != os.path.basename(
+                    last_published_workfile_path
+                )
             ):
-                resource_basename = os.path.basename(resource_main_path)
                 resource_work_path = os.path.join(
                     resources_dir, resource_basename
                 )


### PR DESCRIPTION
## Changelog Description
Fix workfile copied in resources folder on windows.

## Testing notes:
- Download a locally unavailable workfile (fab_old technique) from a local windows machine.
- The resources folder should contain all the resources, but no workfile.
