### PR TITLE
Enhancement: Workfile out of date handling using UTC

### DIFF
--- a/openpype/hosts/blender/api/lib.py
+++ b/openpype/hosts/blender/api/lib.py
@@ -5,10 +5,12 @@ import importlib
 import contextlib
 from pathlib import Path
 from typing import Dict, List, Union
+from datetime import datetime
 
 import bpy
 import addon_utils
 from openpype.lib import Logger
+from openpype.lib.dateutils import get_timestamp
 from openpype.modules import ModulesManager
 from openpype.pipeline import Anatomy
 from openpype.pipeline.template_data import (
@@ -456,7 +458,10 @@ def download_last_workfile(
     ):
         raise OSError("Failed to download last published workfile")
 
-    return last_published_workfile_path, last_version_doc["data"]["time"]
+    return (
+        last_published_workfile_path,
+        get_timestamp(datetime_obj=datetime.utcnow()),
+    )
 
 
 def save_as_local_workfile(

--- a/openpype/hosts/blender/api/workio.py
+++ b/openpype/hosts/blender/api/workio.py
@@ -140,7 +140,10 @@ def check_workfile_up_to_date() -> bool:
 
     scene = bpy.context.scene
 
-    last_published_time = last_published_version["data"]["time"]
+    last_published_time = (
+        last_published_version["data"].get("utc_time")
+        or last_published_version["data"]["time"]
+    )
     if scene.get("op_published_time"):
         return last_published_time <= scene["op_published_time"]
     else:

--- a/openpype/hosts/blender/api/workio.py
+++ b/openpype/hosts/blender/api/workio.py
@@ -140,10 +140,10 @@ def check_workfile_up_to_date() -> bool:
 
     scene = bpy.context.scene
 
-    last_published_time = (
-        last_published_version["data"].get("utc_time")
-        or last_published_version["data"]["time"]
+    last_published_time = last_published_version["data"].get(
+        "utc_time", last_published_version["data"]["time"]
     )
+
     if scene.get("op_published_time"):
         return last_published_time <= scene["op_published_time"]
     else:

--- a/openpype/hosts/blender/plugins/publish/update_current_workfile_last_publish_time.py
+++ b/openpype/hosts/blender/plugins/publish/update_current_workfile_last_publish_time.py
@@ -16,5 +16,5 @@ class UpdateCurrentWorkfileLastPublishTime(pyblish.api.ContextPlugin):
 
     def process(self, context):
         scene = bpy.context.scene
-        scene["op_published_time"] = context.data["time"]
+        scene["op_published_time"] = context.data["utc_time"]
         scene.is_workfile_up_to_date = True

--- a/openpype/hosts/blender/utility_scripts/set_current_time_to_workfile.py
+++ b/openpype/hosts/blender/utility_scripts/set_current_time_to_workfile.py
@@ -1,4 +1,5 @@
 import bpy
+from datetime import datetime
 
 from openpype.lib.log import Logger
 from openpype.lib.dateutils import get_timestamp

--- a/openpype/hosts/blender/utility_scripts/set_current_time_to_workfile.py
+++ b/openpype/hosts/blender/utility_scripts/set_current_time_to_workfile.py
@@ -5,7 +5,7 @@ from openpype.lib.log import Logger
 from openpype.lib.dateutils import get_timestamp
 
 if __name__ == "__main__":
-    current_time = get_timestamp()
+    current_time = get_timestamp(datetime_obj=datetime.utcnow())
 
     log = Logger().get_logger()
     log.debug(f"Setting workfile last publish time to {current_time}")

--- a/openpype/plugins/publish/collect_time.py
+++ b/openpype/plugins/publish/collect_time.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+
 import pyblish.api
-from openpype.lib import get_formatted_current_time
+
+from openpype.lib import get_formatted_current_time, get_timestamp
 
 
 class CollectTime(pyblish.api.ContextPlugin):
@@ -10,3 +13,6 @@ class CollectTime(pyblish.api.ContextPlugin):
 
     def process(self, context):
         context.data["time"] = get_formatted_current_time()
+        context.data["utc_time"] = get_timestamp(
+            datetime_obj=datetime.utcnow()
+        )

--- a/openpype/plugins/publish/integrate.py
+++ b/openpype/plugins/publish/integrate.py
@@ -859,6 +859,7 @@ class IntegrateAsset(pyblish.api.InstancePlugin):
         version_data = {
             "families": get_instance_families(instance),
             "time": context.data["time"],
+            "utc_time": context.data["utc_time"],
             "author": context.data["user"],
             "source": source,
             "comment": instance.data["comment"],


### PR DESCRIPTION
## Changelog Description
Making workfile out of date handling system using UTC time instead of local time. I made this change in a way that wouldn't disturb other features of OpenPype, which still use local time.

## Testing notes:
- Publish a workfile.
- Publish should be succesful and workfile up to date.
- Load a previous workfile.
- It should be out of date.