### PR TITLE
Bugfix: Force download last workfile not triggered

### DIFF
--- a/openpype/tools/launcher/widgets.py
+++ b/openpype/tools/launcher/widgets.py
@@ -369,6 +369,12 @@ class ActionBar(QtWidgets.QWidget):
                     action.data["start_last_workfile"] = False
                 else:
                     action.data.pop("start_last_workfile", None)
+
+                # Set force download last workfile status in action data
+                action.data["force_download_last_workfile"] = (
+                    force_download_last_workfile
+                )
+
             self._start_animation(index)
             self.action_clicked.emit(action)
             return


### PR DESCRIPTION
## Changelog Description
Fix force download last workfile not being triggered.

## Additional note
The bug I'm fixing here doesn't occur in `prod_test`, but it does happen in WW.

## Testing notes:
- Use the force download last workfile feature (in WW prod).
- It should download the last workfile with an incremented version number and `downloaded` subversion whether you have local workfiles or not.